### PR TITLE
feat(ngx-api-utils): `NgxApiUtils#forRoot` implemented again

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import { NgxApiUtilsModule } from 'ngx-api-utils';
 
 @NgModule({
   ...
-  imports: [NgxApiUtilsModule,...]
+  imports: [NgxApiUtilsModule.forRoot(),...]
   ...
 })
 export class AppModule { }
@@ -50,7 +50,7 @@ The package consists of couple of main services and a module that you would use:
   - or even better - have your own implementation of any interceptor you need - to handle errors, transform results or anything you would the same way you would do for Angular's `HttpClient`, just provide it like the defaults are provided with `API_HTTP_INTERCEPTORS` injection token e.g. `{provide: API_HTTP_INTERCEPTORS, useClass: YourCoolInterceptor, multi: true}` to line up with the rest of the default provided [`API_HTTP_INTERCEPTORS`](https://github.com/ngx-api-utils/ngx-api-utils/blob/master/packages/ngx-api-utils/src/lib/ngx-api-utils.module.ts#API_HTTP_INTERCEPTORS)
 - [`ApiAuthGuardService`](https://github.com/ngx-api-utils/ngx-api-utils/blob/master/packages/ngx-api-utils/src/lib/api-auth-guard/api-auth-guard.service.ts) that is a perfectly sane option of you just have public and private part that needs to be protected based on `AuthTokenService` validity and you want a bit more
   - you can of course configure it with urls for `API_AUTH_GUARD_URL_FOR_AUTHENTICATED` and `API_AUTH_GUARD_URL_FOR_AUTHENTICATION`, also a RegExp for `API_AUTH_GUARD_PUBLIC_ONLY_ROUTES`
-- [`NgxApiUtilsModule`](https://github.com/ngx-api-utils/ngx-api-utils/blob/master/packages/ngx-api-utils/src/lib/ngx-api-utils.module.ts) that provides a default set of interceptors for `API_HTTP_INTERCEPTORS` used by the `ApiHttpService` which you can configure through providing your own values for the relevant injection tokens
+- [`NgxApiUtilsModule`](https://github.com/ngx-api-utils/ngx-api-utils/blob/master/packages/ngx-api-utils/src/lib/ngx-api-utils.module.ts) that allows you to easy and handy way to configure the sane defaults services listed above through using `NgxApiUtilsModule#forRoot` method and just passing couple of options
 
 For more details, please check:
 

--- a/packages/ngx-api-utils/src/lib/ngx-api-utils.module.ts
+++ b/packages/ngx-api-utils/src/lib/ngx-api-utils.module.ts
@@ -1,28 +1,124 @@
-import { NgModule } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core';
+import { HttpHeaders, HttpClientModule, HttpInterceptor } from '@angular/common/http';
+import { AUTH_TOKEN_NAME, AUTH_TOKEN_AUTO_REMOVE } from './auth-token/public_api';
 import {
+  API_HTTP_BASE_URL,
+  API_HTTP_DEFAULT_HEADERS,
+  API_HTTP_AUTHORIZATION_HEADER_NAME,
+  API_HTTP_AUTHORIZATION_HEADER_TOKEN_TYPE_PREFIX,
+  API_HTTP_INTERCEPTORS_INJECTION_TOKEN,
   API_HTTP_INTERCEPTORS,
   ApiBaseUrlInterceptor,
   ApiDefaultHeadersInterceptor,
   ApiAuthorizationHeaderInterceptor
 } from './api-http/public_api';
+import {
+  API_AUTH_GUARD_PUBLIC_ONLY_ROUTES,
+  API_AUTH_GUARD_URL_FOR_AUTHENTICATED,
+  API_AUTH_GUARD_URL_FOR_AUTHENTICATION
+} from './api-auth-guard/public_api';
 
 @NgModule({
   imports: [
     HttpClientModule
   ],
   declarations: [],
-  exports: [],
-  providers: [
-    {
-      provide: API_HTTP_INTERCEPTORS, useExisting: ApiBaseUrlInterceptor, multi: true
-    },
-    {
-      provide: API_HTTP_INTERCEPTORS, useExisting: ApiDefaultHeadersInterceptor, multi: true
-    },
-    {
-      provide: API_HTTP_INTERCEPTORS, useExisting: ApiAuthorizationHeaderInterceptor, multi: true
-    }
-  ]
+  exports: []
 })
-export class NgxApiUtilsModule {}
+export class NgxApiUtilsModule {
+  static forRoot(
+    config?: {
+      baseUrl?: string,
+      authTokenName?: string,
+      authTokenAutoRemove?: boolean,
+      defaultHeaders?: HttpHeaders | string | { [name: string]: string | string[]; },
+      authorizationHeaderName?: string,
+      authorizationHeaderTokenTypePrefix?: string,
+      interceptorsInjectionToken?: InjectionToken<InjectionToken<HttpInterceptor[]>>,
+      authGuardPublicOnlyRoutes?: RegExp,
+      authGuardUrlForAuthenticated?: string,
+      authGuardUrlForAuthentication?: string
+    }
+  ): ModuleWithProviders {
+    config = config || {};
+    config = {
+      ...config
+    };
+    const providers = [];
+    if ('authTokenName' in config) {
+      providers.push({
+        provide: AUTH_TOKEN_NAME,
+        useValue: config.authTokenName
+      });
+    }
+    if ('authTokenAutoRemove' in config) {
+      providers.push({
+        provide: AUTH_TOKEN_AUTO_REMOVE,
+        useValue: config.authTokenAutoRemove
+      });
+    }
+    if ('baseUrl' in config) {
+      providers.push({
+        provide: API_HTTP_BASE_URL,
+        useValue: config.baseUrl
+      });
+    }
+    if ('defaultHeaders' in config) {
+      providers.push({
+        provide: API_HTTP_DEFAULT_HEADERS,
+        useValue: config.defaultHeaders
+      });
+    }
+    if ('authorizationHeaderName' in config) {
+      providers.push({
+        provide: API_HTTP_AUTHORIZATION_HEADER_NAME,
+        useValue: config.authorizationHeaderName
+      });
+    }
+    if ('authorizationHeaderTokenTypePrefix' in config) {
+      providers.push({
+        provide: API_HTTP_AUTHORIZATION_HEADER_TOKEN_TYPE_PREFIX,
+        useValue: config.authorizationHeaderTokenTypePrefix
+      });
+    }
+    if ('interceptorsInjectionToken' in config) {
+      providers.push({
+        provide: API_HTTP_INTERCEPTORS_INJECTION_TOKEN,
+        useValue: config.interceptorsInjectionToken
+      });
+    }
+    if ('authGuardPublicOnlyRoutes' in config) {
+      providers.push({
+        provide: API_AUTH_GUARD_PUBLIC_ONLY_ROUTES,
+        useValue: config.authGuardPublicOnlyRoutes
+      });
+    }
+    if ('authGuardUrlForAuthenticated' in config) {
+      providers.push({
+        provide: API_AUTH_GUARD_URL_FOR_AUTHENTICATED,
+        useValue: config.authGuardUrlForAuthenticated
+      });
+    }
+    if ('authGuardUrlForAuthentication' in config) {
+      providers.push({
+        provide: API_AUTH_GUARD_URL_FOR_AUTHENTICATION,
+        useValue: config.authGuardUrlForAuthentication
+      });
+    }
+    return {
+      ngModule: NgxApiUtilsModule,
+      providers: [
+        {
+          provide: API_HTTP_INTERCEPTORS, useExisting: ApiBaseUrlInterceptor, multi: true
+        },
+        {
+          provide: API_HTTP_INTERCEPTORS, useExisting: ApiDefaultHeadersInterceptor, multi: true
+        },
+        {
+          provide: API_HTTP_INTERCEPTORS, useExisting: ApiAuthorizationHeaderInterceptor, multi: true
+        },
+        ...providers
+      ]
+    };
+  }
+}

--- a/packages/ngx-api-utils/src/lib/ngx-api-utils.spec.ts
+++ b/packages/ngx-api-utils/src/lib/ngx-api-utils.spec.ts
@@ -3,14 +3,9 @@ import { NgxApiUtilsModule, AuthTokenService, ApiHttpService, TokenPayload } fro
 import { Polly } from '@pollyjs/core';
 import * as XHRAdapter from '@pollyjs/adapter-xhr';
 import * as FetchAdapter from '@pollyjs/adapter-fetch';
-import { TokenDecoder, AUTH_TOKEN_NAME } from './auth-token/public_api';
+import { TokenDecoder } from './auth-token/public_api';
 import { ApiErrorsInterceptor } from './api-http/interceptors/api-errors/api-errors.interceptor';
-import {
-  API_HTTP_INTERCEPTORS,
-  API_HTTP_BASE_URL,
-  API_HTTP_DEFAULT_HEADERS,
-  API_HTTP_AUTHORIZATION_HEADER_NAME
-} from './api-http/public_api';
+import { API_HTTP_INTERCEPTORS } from './api-http/public_api';
 import { HttpErrorResponse } from '@angular/common/http';
 
 /*
@@ -35,25 +30,7 @@ describe('ngx-api-utils package', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NgxApiUtilsModule
-      ],
-      providers: [
-        {
-          provide: API_HTTP_BASE_URL,
-          useValue: apiUtilsConfig.baseUrl
-        },
-        {
-          provide: AUTH_TOKEN_NAME,
-          useValue: apiUtilsConfig.authTokenName
-        },
-        {
-          provide: API_HTTP_DEFAULT_HEADERS,
-          useValue: apiUtilsConfig.defaultHeaders
-        },
-        {
-          provide: API_HTTP_AUTHORIZATION_HEADER_NAME,
-          useValue: apiUtilsConfig.authorizationHeaderName
-        }
+        NgxApiUtilsModule.forRoot(apiUtilsConfig)
       ]
     });
     polly = new Polly('ngx-api-utils', {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { NgxApiUtilsModule } from 'ngx-api-utils';
 import { CoreModule } from './core/core.module';
 
 @NgModule({
@@ -12,10 +13,16 @@ import { CoreModule } from './core/core.module';
   imports: [
     BrowserModule,
     AppRoutingModule,
+    NgxApiUtilsModule.forRoot({
+      baseUrl: '//localhost:3000',
+      authTokenAutoRemove: true,
+      authGuardPublicOnlyRoutes: /^\/(customer\/auth)([\/#?].*)?$/,
+      authGuardUrlForAuthenticated: '/customer/',
+      authGuardUrlForAuthentication: '/customer/auth/sign-in'
+    }),
     CoreModule.forRoot()
   ],
-  providers: [
-  ],
+  providers: [],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,17 +1,8 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders } from '@angular/compiler/src/core';
-import {
-  TokenDecoder,
-  NgxApiUtilsModule,
-  API_HTTP_BASE_URL,
-  API_AUTH_GUARD_PUBLIC_ONLY_ROUTES,
-  API_AUTH_GUARD_URL_FOR_AUTHENTICATION,
-  API_AUTH_GUARD_URL_FOR_AUTHENTICATED
-} from 'ngx-api-utils';
+import { TokenDecoder, NgxApiUtilsModule } from 'ngx-api-utils';
 import { JwtTokenDecoderService } from './fake-api/jwt-token-decoder/jwt-token-decoder.service';
-
-export const publicOnlyRoutesRegexp = /^\/(customer\/auth)([\/#?].*)?$/;
 
 @NgModule({
   imports: [
@@ -31,22 +22,6 @@ export class CoreModule {
     return {
       ngModule: CoreModule,
       providers: [
-        {
-          provide: API_HTTP_BASE_URL,
-          useValue: '//localhost:3000'
-        },
-        {
-          provide: API_AUTH_GUARD_PUBLIC_ONLY_ROUTES,
-          useValue: publicOnlyRoutesRegexp
-        },
-        {
-          provide: API_AUTH_GUARD_URL_FOR_AUTHENTICATED,
-          useValue: '/customer/'
-        },
-        {
-          provide: API_AUTH_GUARD_URL_FOR_AUTHENTICATION,
-          useValue: '/customer/'
-        },
         {
           provide: TokenDecoder,
           useClass: JwtTokenDecoderService


### PR DESCRIPTION
blocked by https://github.com/angular/angular/issues/23609
when `npm run build -- --prod` I get the following error caused by the issue linked above:
```
...
[demo:build -- --prod         ] > ng build "--prod"
[demo:build -- --prod         ] 
[demo:build -- --prod         ]                                                                                    
[demo:build -- --prod         ] Date: 2018-07-26T07:23:59.093Z
[demo:build -- --prod         ] Hash: 5768624b1d80f4408013
[demo:build -- --prod         ] Time: 6019ms
[demo:build -- --prod         ] chunk {0} runtime.a66f828dca56eeb90e02.js (runtime) 1.05 kB [entry] [rendered]
[demo:build -- --prod         ] chunk {1} styles.7d4d4ec7449ea1db183a.css (styles) 128 kB [initial] [rendered]
[demo:build -- --prod         ] chunk {2} polyfills.cdf87a8e5b31fe8a11f1.js (polyfills) 130 bytes [initial] [rendered]
[demo:build -- --prod         ] chunk {3} main.a2bc6cab25d0aa41c17a.js (main) 128 bytes [initial] [rendered]
[demo:build -- --prod         ] 
[demo:build -- --prod         ] ERROR in Error during template compile of 'AppModule'
[demo:build -- --prod         ]   Function calls are not supported in decorators but 'NgxApiUtilsModule' was called.
[demo:build -- --prod         ]
...
```