### PR TITLE
feat(utils): `prepareParams` util for GET params

### DIFF
--- a/packages/ngx-api-utils/src/lib/utils/prepare-params.spec.ts
+++ b/packages/ngx-api-utils/src/lib/utils/prepare-params.spec.ts
@@ -1,0 +1,28 @@
+import {prepareParams} from './prepare-params';
+
+describe('utils/prepareParams', () => {
+  it('it should filter any undefined value and cast to string', () => {
+    const testSets = [
+      {input: {}, expected: {}, expectationFailOutput: 'empty object failed'},
+      {input: {num: 99}, expected: {num: '99'}, expectationFailOutput: 'object with number failed'},
+      {
+        input: {date: new Date('2018-07-30')},
+        expected: {date: String(new Date('2018-07-30'))},
+        expectationFailOutput: 'object with date failed'
+      },
+      {
+        input: {a: 'valueofa', b: undefined},
+        expected: {a: 'valueofa'},
+        expectationFailOutput: 'object property and another that is undefined failed'
+      },
+      {
+        input: {a: undefined, b: undefined},
+        expected: {},
+        expectationFailOutput: 'object with undefined properties only'
+      }
+    ] as any;
+    for (const test of testSets) {
+      expect(prepareParams(test.input)).toEqual(jasmine.objectContaining(test.expected), test.expectationFailOutput);
+    }
+  });
+});

--- a/packages/ngx-api-utils/src/lib/utils/prepare-params.ts
+++ b/packages/ngx-api-utils/src/lib/utils/prepare-params.ts
@@ -1,0 +1,15 @@
+/**
+ * Filters object properties stripping any `undefined` value and naively casting any value to string
+ * This is quite useful for preparing params for GET requests
+ */
+export function prepareParams(params: Record<string, any>): Record<string, string> {
+  return Object.entries(params).reduce(
+    (preparedParams, [k, v]) => {
+      if (v !== undefined) {
+        preparedParams[k] = String(v);
+      }
+      return preparedParams;
+    },
+    {} as Record<string, string>
+  );
+}

--- a/packages/ngx-api-utils/src/lib/utils/public_api.ts
+++ b/packages/ngx-api-utils/src/lib/utils/public_api.ts
@@ -1,0 +1,1 @@
+export * from './prepare-params';

--- a/packages/ngx-api-utils/src/public_api.ts
+++ b/packages/ngx-api-utils/src/public_api.ts
@@ -4,4 +4,5 @@
 export * from './lib/auth-token/public_api';
 export * from './lib/api-auth-guard/public_api';
 export * from './lib/api-http/public_api';
+export * from './lib/utils/public_api';
 export * from './lib/ngx-api-utils.module';


### PR DESCRIPTION
Filters object properties stripping any `undefined` value and naively casting any value to string